### PR TITLE
change cl-arrows dependency to arrows

### DIFF
--- a/cloture.asd
+++ b/cloture.asd
@@ -3,7 +3,7 @@
   :license "EPL-1.0"
   :depends-on ("serapeum"
                "trivia.ppcre"
-               "cl-arrows"
+               "arrows"
                "fset"
                "named-readtables"
                "fare-utils"


### PR DESCRIPTION
cl-arrows has been removed from QuickLisp due to licensing issues, but I believe arrows is a good alternative that i think has very similar semantics. I wasn't able to figure out how to run the tests (I got a read error when compiling them), but I'd be surprised if this change affected anything's behavior.