### PR TITLE
Fix hash-map arguments processing

### DIFF
--- a/clojure/core.lisp
+++ b/clojure/core.lisp
@@ -2802,7 +2802,7 @@ Analogous to `mapcar'."
   ((ns name) (make-keyword (string+ ns "/" name))))
 
 (defun-1 #_hash-map (&rest keys-and-vals &key &allow-other-keys)
-  (reduce #'with
+  (reduce (lambda (map kv) (with map (first kv) (second kv)))
           (batches keys-and-vals 2 :even t)
           :initial-value (empty-map)))
 


### PR DESCRIPTION
it works now from Lisp:
```
> (|clojure.core|:|hash-map| :a 1 :b 2)
{:A 1 :B 2}
``` 

and from Clojure:
```
> (hash-map :a 3 :b 7)
{ :a 3 :b 7}
```

Originally, it was complaining that _with_ takes 3 arguments.