### PR TITLE
Fix sequential equality: a prefix is not an equal

### DIFF
--- a/clojure/core.lisp
+++ b/clojure/core.lisp
@@ -1178,7 +1178,16 @@ nested)."
   (#_lookup (coll _ default) default)
   (#_lookup (coll _) #_nil)
   #_IEquiv
-  (#_equiv (n x) (or (null x) (and (#_seq? x)) (#_empty? x)))
+  (#_equiv (n x)
+           (? (or (null x)
+                  ;; Check it is a non-nil, non-map, non-set seq before
+                  ;; checking if empty: `empty?' has no method for a
+                  ;; non-seqable, and nil is not an empty list.
+                  (and (not (nil? x))
+                       (truthy? (#_seq? x))
+                       (falsy? (#_map? x))
+                       (falsy? (#_set? x))
+                       (truthy? (#_empty? x))))))
   #_IReduce
   (#_internal-reduce (coll _ start) start)
   (#_internal-reduce (coll f) (ifncall f)))
@@ -2408,7 +2417,15 @@ Analogous to `mapcar'."
            (truthy? (#_= (#_first self) (#_first other)))
            (truthy? (#_= (#_rest self) (#_rest other))))
           nil)
-      (not (seq? other))))
+      ;; SELF is an empty sequential collection. Only another empty
+      ;; sequential collection is equal to it -- not a number, not nil, and
+      ;; not an empty map or set.
+      (and (not (seq? other))
+           (not (nil? other))
+           (falsy? (#_map? other))
+           (falsy? (#_set? other))
+           (seqable? other)
+           (truthy? (#_empty? other)))))
 
 (defunion for-control
   skip

--- a/t/cloture-tests.cljc
+++ b/t/cloture-tests.cljc
@@ -847,3 +847,52 @@
 (deftest test-parse-integer
   (is (= 234
          (parse-integer "1234x" :start 1 :junk-allowed true))))
+
+;;; A prefix is not an equal. Sequential equality must compare lengths in
+;;; both directions, and an empty sequential collection must not swallow
+;;; nil, a number, an empty map or an empty set.
+
+(deftest test-sequential-equality-is-length-sensitive
+  (is (= '(1 2 3) [1 2 3]))
+  (is (not= '(1 2) '(1 2 3)))
+  (is (not= '(1 2 3) '(1 2)))
+  (is (not= '(1 2 3) [1 2 3 4]))
+  (is (not= '(1 2 3 4) [1 2 3]))
+  (is (not= [1] [1 2]))
+  (is (not= [1 2] [1]))
+  (is (not= '([:x 1] [:y 2]) (seq {:x 1 :y 2 :z 3})))
+  (is (not= (map inc [1 2]) '(2 3 4))))
+
+(deftest test-empty-collection-equality
+  (testing "empty sequential collections are equal to each other"
+    (is (= () []))
+    (is (= [] ()))
+    (is (= (list) []))
+    (is (= (rest [1]) []))
+    (is (= (rest '(1)) ())))
+  (testing "an empty sequential collection is not equal to nil"
+    (is (not= () nil))
+    (is (not= nil ()))
+    (is (not= [] nil))
+    (is (not= nil [])))
+  (testing "an empty sequential collection is not equal to an empty map or set"
+    (is (not= () {}))
+    (is (not= [] {}))
+    (is (not= () #{}))
+    (is (not= [] #{})))
+  (testing "an empty sequential collection is not equal to a non-collection"
+    (is (not= [] 4))
+    (is (not= () 4))
+    (is (not= [] ""))
+    (is (not= () ""))))
+
+(deftest test-equality-is-symmetric
+  (are [x y] (= (= x y) (= y x))
+    () nil
+    [] nil
+    () []
+    [] {}
+    () #{}
+    [] 4
+    '(1 2) '(1 2 3)
+    '(1 2 3) [1 2 3 4]))


### PR DESCRIPTION
`=` reported two sequential collections equal whenever the shorter one was a
prefix of the longer, and reported an empty sequential collection equal to
`nil`, a number, an empty map or an empty set. `=` was therefore not symmetric,
which also makes it unsound as the equality underneath hash-based collections.

```lisp
(= '(1 2) '(1 2 3))   ; => true   ; shorter operand is a PREFIX of the longer
(= '(1 2 3) '(1 2))   ; => false  ; ...but only in one direction
(= [] 4)              ; => true
(= [] {})             ; => true
(= [] #{})            ; => true
(= () nil)            ; => true   ; while (= nil ()) => false
```

## Two causes, both at the terminating comparison of the recursion

1. `clojure/core.lisp`, the empty list's `IEquiv`:

   ```lisp
   (#_equiv (n x) (or (null x) (and (#_seq? x)) (#_empty? x)))
   ```

   A one-armed `and`: `(#_empty? x)` sits as its own `or` clause, so any seq —
   empty or not — satisfied it. Sequential `=` recurses via
   `(#_= (#_rest self) (#_rest other))` and bottoms out in `(= () '(3))`, which
   this returned true for. Introduced by 925b1ef ("Check if a seq before
   checking if empty"): the `seq?` guard was added, the conjunction was not
   closed around it.

2. `coll=`'s else branch, `(not (seq? other))`. Here `cloture::seq?` means "is a
   non-empty seq", so an empty collection fell through to a branch declaring it
   equal to anything that was not a non-empty seq — `4`, `{}` and `#{}`
   included.

Both branches now require the other side to be non-nil, non-map, non-set,
seqable and empty.

`coll=` uses the CL-level `nil?` from core.lisp rather than
`clojure.core/nil?`: the latter is defined in core2.lisp, and `coll=` is called
during core2's own compilation (the `and` macro constant-folds through it), so
`#_nil?` there fails the build with "defined earlier in the file but is not
available at compile-time".

## Verification

- `(asdf:test-system :cloture-test)` on a cold SBCL 2.6.7 image:
  129 tests, 332 assertions, 0 failures.
- Reverting `clojure/core.lisp` alone — keeping the new tests — reproduces
  **19 failures**, so the added regression tests are not vacuous.
- A 33-case conformance sweep against real Clojure's answers went 25/33 before
  to 33/33 after.

## Tests added

`test-sequential-equality-is-length-sensitive`, `test-empty-collection-equality`
and `test-equality-is-symmetric` (the last asserts `(= (= x y) (= y x))` over
the pairs above with `are`).
